### PR TITLE
Ignore server capabilities by default.

### DIFF
--- a/lib/github/ldap/domain.rb
+++ b/lib/github/ldap/domain.rb
@@ -115,6 +115,7 @@ module GitHub
       def search(options)
         options[:base] = @base_name
         options[:attributes] ||= %w{ou cn dn sAMAccountName member}
+        options[:ignore_server_caps] ||= true
 
         @connection.search(options)
       end


### PR DESCRIPTION
Because Net::LDAP tries to search in the root domain and it's pretty likely
that it doesn't have privileges for it.
