### PR TITLE
Pass through `get_operation_result`.

### DIFF
--- a/lib/github/ldap/domain.rb
+++ b/lib/github/ldap/domain.rb
@@ -120,6 +120,16 @@ module GitHub
 
         @connection.search(options)
       end
+
+      # Provide a meaningful result after a protocol operation (for example,
+      # bind or search) has completed.
+      #
+      # Returns an OpenStruct containing an LDAP result code and a
+      # human-readable string.
+      # See http://tools.ietf.org/html/rfc4511#appendix-A
+      def get_operation_result
+        @connection.get_operation_result
+      end
     end
   end
 end


### PR DESCRIPTION
This lets us log bind and search errors and tell users what went wrong.
