### PR TITLE
Use paged result sets by default

### DIFF
--- a/lib/github/ldap/domain.rb
+++ b/lib/github/ldap/domain.rb
@@ -117,6 +117,7 @@ module GitHub
         options[:base] = @base_name
         options[:attributes] ||= %w{ou cn dn sAMAccountName member}
         options[:ignore_server_caps] ||= true
+        options[:paged_searches_supported] ||= true
 
         @connection.search(options)
       end


### PR DESCRIPTION
Using the paged results control prevents Active Directory from exploding if there are too many results.
