### PR TITLE
Prevent infinite loops looking for group members and subgroups.

### DIFF
--- a/test/fixtures/github-with-looped-subgroups.ldif
+++ b/test/fixtures/github-with-looped-subgroups.ldif
@@ -1,0 +1,91 @@
+version: 1
+
+# Organizations
+
+dn: dc=github,dc=com
+cn: github
+objectClass: dcObject
+objectClass: organization
+dc: github
+o: GitHub Inc.
+
+# Admin user
+
+dn: uid=admin,dc=github,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: system administrator
+sn: administrator
+displayName: Directory Superuser
+uid: admin
+userPassword: secret
+
+# Groups
+
+dn: ou=groups,dc=github,dc=com
+objectclass: organizationalUnit
+
+dn: cn=enterprise,ou=groups,dc=github,dc=com
+cn: Enterprise
+objectClass: groupOfNames
+member: uid=calavera,ou=users,dc=github,dc=com
+member: cn=enterprise-devs,ou=groups,dc=github,dc=com
+member: cn=enterprise-ops,ou=groups,dc=github,dc=com
+
+dn: cn=enterprise-devs,ou=groups,dc=github,dc=com
+cn: enterprise-devs
+objectClass: groupOfNames
+member: uid=benburkert,ou=users,dc=github,dc=com
+member: cn=enterprise,ou=groups,dc=github,dc=com
+
+dn: cn=enterprise-ops,ou=groups,dc=github,dc=com
+cn: enterprise-ops
+objectClass: groupOfNames
+member: uid=sbryant,ou=users,dc=github,dc=com
+member: cn=spaniards,ou=groups,dc=github,dc=com
+
+dn: cn=spaniards,ou=groups,dc=github,dc=com
+cn: spaniards
+objectClass: groupOfNames
+member: uid=calavera,ou=users,dc=github,dc=com
+member: uid=rubiojr,ou=users,dc=github,dc=com
+
+# Users
+
+dn: ou=users,dc=github,dc=com
+objectclass: organizationalUnit
+
+dn: uid=calavera,ou=users,dc=github,dc=com
+cn: David Calavera
+cn: David
+sn: Calavera
+uid: calavera
+userPassword: passworD1
+mail: calavera@github.com
+objectClass: inetOrgPerson
+
+dn: uid=benburkert,ou=users,dc=github,dc=com
+cn: benburkert
+sn: benburkert
+uid: benburkert
+userPassword: passworD1
+mail: benburkert@github.com
+objectClass: inetOrgPerson
+
+dn: uid=sbryant,ou=users,dc=github,dc=com
+cn: sbryant
+sn: sbryant
+uid: sbryant
+userPassword: passworD1
+mail: sbryant@github.com
+objectClass: inetOrgPerson
+
+dn: uid=rubiojr,ou=users,dc=github,dc=com
+cn: rubiojr
+sn: rubiojr
+uid: rubiojr
+userPassword: passworD1
+mail: rubiojr@github.com
+objectClass: inetOrgPerson

--- a/test/group_test.rb
+++ b/test/group_test.rb
@@ -31,3 +31,17 @@ class GitHubLdapGroupTest < GitHub::Ldap::Test
     assert_equal 1, groups.size
   end
 end
+
+class GitHubLdapLoopedGroupTest < GitHub::Ldap::Test
+  def self.test_server_options
+    {user_fixtures: FIXTURES.join('github-with-looped-subgroups.ldif').to_s}
+  end
+
+  def setup
+    @group = GitHub::Ldap.new(options).group("cn=enterprise,ou=groups,dc=github,dc=com")
+  end
+
+  def test_members_from_subgroups
+    assert_equal 4, @group.members.size
+  end
+end


### PR DESCRIPTION
Because we cannot prevent of :poop: happening.

/cc @sbryant, @mtodd
