### PR TITLE
Fix virtual group search.

### DIFF
--- a/lib/github/ldap/virtual_group.rb
+++ b/lib/github/ldap/virtual_group.rb
@@ -1,6 +1,8 @@
 module GitHub
   class Ldap
     class VirtualGroup < Group
+      include Filter
+
       def members
         @ldap.search(filter: members_of_group(@entry.dn, membership_attribute))
       end
@@ -17,7 +19,7 @@ module GitHub
       #
       # Returns a string.
       def membership_attribute
-        @ldap.virual_attributes.virtual_membership
+        @ldap.virtual_attributes.virtual_membership
       end
     end
   end


### PR DESCRIPTION
There are a few things wrong with this implementation. I've noticed that members of a group are not returned even when the overlay is working properly.

```
ubuntu@ubuntu:~$ sudo ldapsearch -LLL -Y EXTERNAL -H ldapi:/// -b "dc=github,dc=com" "(memberof=cn=Assets,ou=teams,dc=github,dc=com)"
SASL/EXTERNAL authentication started
SASL username: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
SASL SSF: 0
dn: uid=calavera,ou=users,dc=github,dc=com
cn: calavera
sn: calavera
uid: calavera
mail: calavera@github.com
objectClass: inetOrgPerson

dn: uid=pengwynn,ou=users,dc=github,dc=com
cn: pengwynn
sn: pengwynn
uid: pengwynn
mail: pengwynn@github.com
objectClass: inetOrgPerson

dn: uid=rubyist,ou=users,dc=github,dc=com
cn: rubyist
sn: rubyist
uid: rubyist
mail: rubyist@github.com
objectClass: inetOrgPerson

dn: uid=sbryant,ou=users,dc=github,dc=com
cn: sbryant
sn: sbryant
uid: sbryant
mail: sbryant@github.com
objectClass: inetOrgPerson

dn: uid=technoweenie,ou=users,dc=github,dc=com
cn: technoweenie
sn: technoweenie
uid: technoweenie
mail: technoweenie@github.com
objectClass: inetOrgPerson
```

:warning: **WIP** :warning:

/cc @mtodd
