### PR TITLE
Verify membership when the dn is in the direct list of members for a group.

### DIFF
--- a/lib/github/ldap/group.rb
+++ b/lib/github/ldap/group.rb
@@ -41,7 +41,8 @@ module GitHub
       #
       # Returns true if the dn is in the list of members.
       def is_member?(user_dn)
-        members.detect {|entry| entry.dn == user_dn}
+        member_names.include?(user_dn) ||
+          members.detect {|entry| entry.dn == user_dn}
       end
 
 


### PR DESCRIPTION
This saves us from sending a lot of requests for direct members of a group.

/cc @mtodd
