### PR TITLE
Limit scope and size of searches to bind entries.

### DIFF
--- a/lib/github/ldap/domain.rb
+++ b/lib/github/ldap/domain.rb
@@ -97,7 +97,7 @@ module GitHub
       # Returns the user if the login matches any `uid`.
       # Returns nil if there are no matches.
       def user?(login)
-        search(filter: login_filter(@uid, login), limit: 1).first
+        search(filter: login_filter(@uid, login), size: 1).first
       end
 
       # Check if a user can be bound with a password.
@@ -153,7 +153,7 @@ module GitHub
       #
       # Returns a Net::LDAP::Entry
       def bind
-        search({}).first
+        search(size: 1, scope: Net::LDAP::SearchScope_BaseObject).first
       end
     end
   end


### PR DESCRIPTION
This fixes some issues binding objects on Active Directory.
