### PR TITLE
Allow to limit the group matching size.

### DIFF
--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -95,14 +95,15 @@ module GitHub
     # Public - Search entries in the ldap server.
     #
     # options: is a hash with the same options that Net::LDAP::Connection#search supports.
+    # block: is an optional block to pass to the search.
     #
     # Returns an Array of Net::LDAP::Entry.
-    def search(options)
+    def search(options, &block)
       result = if options[:base]
-        @connection.search(options)
+        @connection.search(options, &block)
       else
         search_domains.each_with_object([]) do |base, result|
-          rs = @connection.search(options.merge(:base => base))
+          rs = @connection.search(options.merge(:base => base), &block)
           result.concat Array(rs) unless rs == false
         end
       end

--- a/lib/github/ldap/domain.rb
+++ b/lib/github/ldap/domain.rb
@@ -27,9 +27,13 @@ module GitHub
 
       # List all groups under this tree that match the query.
       #
+      # query: is the partial name to filter for.
+      # opts: additional options to filter with. It's specially recommended to restrict this search by size.
+      # block: is an optional block to pass to the search.
+      #
       # Returns a list of ldap entries.
-      def filter_groups(query)
-        search(filter: group_contains_filter(query))
+      def filter_groups(query, opts = {}, &block)
+        search(opts.merge(filter: group_contains_filter(query)), &block)
       end
 
       # List the groups in the ldap server that match the configured ones.
@@ -97,7 +101,7 @@ module GitHub
       # Returns the user if the login matches any `uid`.
       # Returns nil if there are no matches.
       def user?(login)
-        search(filter: login_filter(@uid, login), limit: 1).first
+        search(filter: login_filter(@uid, login), size: 1).first
       end
 
       # Check if a user can be bound with a password.
@@ -127,16 +131,16 @@ module GitHub
 
       # Search entries using this domain as base.
       #
-      # options: is a Hash with the options for the search.
-      # The base option is always overriden.
+      # options: is a Hash with the options for the search. The base option is always overriden.
+      # block: is an optional block to pass to the search.
       #
       # Returns an array with the entries found.
-      def search(options)
+      def search(options, &block)
         options[:base] = @base_name
         options[:attributes] ||= []
         options[:paged_searches_supported] = true
 
-        @ldap.search(options)
+        @ldap.search(options, &block)
       end
 
       # Provide a meaningful result after a protocol operation (for example,

--- a/test/group_test.rb
+++ b/test/group_test.rb
@@ -32,6 +32,19 @@ class GitHubLdapGroupTest < GitHub::Ldap::Test
     assert_equal 1, groups.size
   end
 
+  def test_filter_domain_groups_limited
+    groups = []
+    groups_domain.filter_groups('enter', size: 1) do |entry|
+      groups << entry
+    end
+    assert_equal 1, groups.size
+  end
+
+  def test_filter_domain_groups_unlimited
+    groups = groups_domain.filter_groups('ent')
+    assert_equal 3, groups.size
+  end
+
   def test_unknown_group
     refute @ldap.group("cn=foobar,ou=groups,dc=github,dc=com"),
       "Expected to not bind any group"


### PR DESCRIPTION
Because a `contains` filter might return too many results. Causing performance issues.
Also allow to pass a block to the ldap searches.

/cc @mtodd
