### PR TITLE
Bump version to v1.3.0

### DIFF
--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "github-ldap"
-  spec.version       = "1.2.1"
+  spec.version       = "1.3.0"
   spec.authors       = ["David Calavera"]
   spec.email         = ["david.calavera@gmail.com"]
   spec.description   = %q{Ldap authentication for humans}


### PR DESCRIPTION
Includes #33 to fix posixGroup membership queries and #35 to update net-ldap to latest release.

Since `member_filter` is changing signature to accept a `Net::LDAP::Entry` (instead of a `dn` `String`), as well as an optional `uid_attr` `String`, I'm bumping the minor as this is backwards incompatible.
