### PR TITLE
Add support for instrumentation

### DIFF
--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -28,7 +28,11 @@ module GitHub
     def initialize(options = {})
       @uid = options[:uid] || "sAMAccountName"
 
-      @connection = Net::LDAP.new({host: options[:host], port: options[:port]})
+      @connection = Net::LDAP.new({
+        host: options[:host],
+        port: options[:port],
+        instrumentation_service: options[:instrumentation_service]
+      })
 
       if options[:admin_user] && options[:admin_password]
         @connection.authenticate(options[:admin_user], options[:admin_password])


### PR DESCRIPTION
In support of https://github.com/ruby-ldap/ruby-net-ldap/pull/101, this handles passing along the an `instrumentation_service` object to `Net::LDAP` so that network calls are instrumented. This also enables us to instrument higher level events like `GitHub::Ldap#search` et al.

cc @rtomayko 
