### PR TITLE
Add VirtualAttributes membership validator

### DIFF
--- a/lib/github/ldap/membership_validators.rb
+++ b/lib/github/ldap/membership_validators.rb
@@ -1,6 +1,7 @@
 require 'github/ldap/membership_validators/base'
 require 'github/ldap/membership_validators/classic'
 require 'github/ldap/membership_validators/recursive'
+require 'github/ldap/membership_validators/virtual_attributes'
 
 module GitHub
   class Ldap

--- a/lib/github/ldap/membership_validators/virtual_attributes.rb
+++ b/lib/github/ldap/membership_validators/virtual_attributes.rb
@@ -1,0 +1,76 @@
+module GitHub
+  class Ldap
+    module MembershipValidators
+      # Validates membership recursively using virtual attributes.
+      class VirtualAttributes < Base
+        include Filter
+
+        DEFAULT_MAX_DEPTH = 9
+        ATTRS             = %w(dn cn memberOf)
+
+        def perform(entry, depth = DEFAULT_MAX_DEPTH)
+          return true if groups.empty?
+
+          domains.each do |domain|
+            # get groups entry is an immediate member of
+            membership = entry[member_of_attr]
+
+            # success if any of these groups match the restricted auth groups
+            return true if membership.any? { |entry| group_dns.include?(entry.dn) }
+
+            # give up if the entry has no memberships to recurse
+            next if membership.empty?
+
+            # recurse to at most `depth`
+            depth.times do |n|
+              # find groups whose members include membership groups
+              membership = domain.search(filter: membership_filter(membership), attributes: ATTRS)
+
+              # success if any of these groups match the restricted auth groups
+              return true if membership.any? { |entry| group_dns.include?(entry.dn) }
+
+              # give up if there are no more membersips to recurse
+              break if membership.empty?
+            end
+
+            # give up on this base if there are no memberships to test
+            next if membership.empty?
+          end
+
+          false
+        end
+
+        # Internal: Returns the String memberOf virtual attribute name.
+        def member_of_attr
+          @member_of_attr ||= ldap.virtual_attributes.virtual_membership
+        end
+
+        # Internal: Construct a filter to find groups this entry is a direct
+        # member of.
+        #
+        # Overloads the included `GitHub::Ldap::Filters#member_filter` method
+        # to inject `posixGroup` handling.
+        #
+        # Returns a Net::LDAP::Filter object.
+        def member_filter(entry)
+          Net::LDAP::Filter.eq(member_of_attr, entry.dn)
+        end
+
+        # Internal: Construct a filter to find groups whose members are the
+        # Array of String group DNs passed in.
+        #
+        # Returns a String filter.
+        def membership_filter(groups)
+          groups.map { |entry| member_filter(entry) }.reduce(:|)
+        end
+
+        # Internal: the group DNs to check against.
+        #
+        # Returns an Array of String DNs.
+        def group_dns
+          @group_dns ||= groups.map(&:dn)
+        end
+      end
+    end
+  end
+end

--- a/test/membership_validators/virtual_attributes_test.rb
+++ b/test/membership_validators/virtual_attributes_test.rb
@@ -1,0 +1,59 @@
+require_relative '../test_helper'
+
+class GitHubLdapVirtualAttributesMembershipValidatorsTest < GitHub::Ldap::Test
+  def setup
+    opts = options.merge \
+      search_domains: %w(dc=github,dc=com),
+      virtual_attributes: true
+    @ldap      = GitHub::Ldap.new(opts)
+    @domain    = @ldap.domain("dc=github,dc=com")
+    @entry     = @domain.user?('user1', :attributes => %w(dn cn memberOf))
+    @validator = GitHub::Ldap::MembershipValidators::VirtualAttributes
+  end
+
+  def make_validator(groups)
+    groups = @domain.groups(groups)
+    @validator.new(@ldap, groups)
+  end
+
+  def test_validates_user_in_group
+    validator = make_validator(%w(nested-group1))
+    assert validator.perform(@entry)
+  end
+
+  def test_validates_user_in_child_group
+    validator = make_validator(%w(n-depth-nested-group1))
+    assert validator.perform(@entry)
+  end
+
+  def test_validates_user_in_grandchild_group
+    validator = make_validator(%w(n-depth-nested-group2))
+    assert validator.perform(@entry)
+  end
+
+  def test_validates_user_in_great_grandchild_group
+    validator = make_validator(%w(n-depth-nested-group3))
+    assert validator.perform(@entry)
+  end
+
+  def test_does_not_validate_user_in_great_granchild_group_with_depth
+    validator = make_validator(%w(n-depth-nested-group3))
+    refute validator.perform(@entry, 2)
+  end
+
+  def test_does_not_validate_user_not_in_group
+    validator = make_validator(%w(ghe-admins))
+    refute validator.perform(@entry)
+  end
+
+  def test_does_not_validate_user_not_in_any_group
+    @entry = @domain.user?('groupless-user1')
+    validator = make_validator(%w(all-users))
+    refute validator.perform(@entry)
+  end
+
+  def test_validates_user_in_posix_group
+    validator = make_validator(%w(posix-group1))
+    assert validator.perform(@entry)
+  end
+end

--- a/test/membership_validators/virtual_attributes_test.rb
+++ b/test/membership_validators/virtual_attributes_test.rb
@@ -17,21 +17,30 @@ class GitHubLdapVirtualAttributesMembershipValidatorsTest < GitHub::Ldap::Test
   end
 
   def test_validates_user_in_group
+    # fake for ApacheDS
+    @entry['memberOf'] = %w(cn=nested-group1,ou=Groups,dc=github,dc=com) if TESTENV == "apacheds"
+
     validator = make_validator(%w(nested-group1))
     assert validator.perform(@entry)
   end
 
   def test_validates_user_in_child_group
+    skip "no memberOf support for ApacheDS" if TESTENV == "apacheds"
+
     validator = make_validator(%w(n-depth-nested-group1))
     assert validator.perform(@entry)
   end
 
   def test_validates_user_in_grandchild_group
+    skip "no memberOf support for ApacheDS" if TESTENV == "apacheds"
+
     validator = make_validator(%w(n-depth-nested-group2))
     assert validator.perform(@entry)
   end
 
   def test_validates_user_in_great_grandchild_group
+    skip "no memberOf support for ApacheDS" if TESTENV == "apacheds"
+
     validator = make_validator(%w(n-depth-nested-group3))
     assert validator.perform(@entry)
   end
@@ -53,6 +62,9 @@ class GitHubLdapVirtualAttributesMembershipValidatorsTest < GitHub::Ldap::Test
   end
 
   def test_validates_user_in_posix_group
+    # fake for ApacheDS
+    @entry['memberOf'] = %w(cn=posix-group1,ou=Groups,dc=github,dc=com) if TESTENV == "apacheds"
+
     validator = make_validator(%w(posix-group1))
     assert validator.perform(@entry)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ __lib__ = File.expand_path('lib', File.dirname(__FILE__))
 $LOAD_PATH << __dir__ unless $LOAD_PATH.include?(__dir__)
 $LOAD_PATH << __lib__ unless $LOAD_PATH.include?(__lib__)
 
+TESTENV = ENV.fetch('TESTENV', "apacheds")
+
 require 'pathname'
 FIXTURES = Pathname(File.expand_path('fixtures', __dir__))
 
@@ -12,7 +14,7 @@ require 'github/ldap/server'
 
 require 'minitest/autorun'
 
-if ENV.fetch('TESTENV', "apacheds") == "apacheds"
+if TESTENV == "apacheds"
   # Make sure we clean up running test server
   # NOTE: We need to do this manually since its internal `at_exit` hook
   # collides with Minitest's autorun at_exit handling, hence this hook.


### PR DESCRIPTION
First pass at getting a working Virtual Attributes membership validator working.

Will fail with ApacheDS because it doesn't support `memberOf`. Could fake it, though.

Pushed to see how the tests work with OpenLDAP though.

cc @jch 
