### PR TITLE
Add logger accessor

### DIFF
--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -36,6 +36,8 @@ module GitHub
     attr_reader :uid, :search_domains, :virtual_attributes,
                 :instrumentation_service
 
+    attr_accessor :logger
+
     def initialize(options = {})
       @uid = options[:uid] || "sAMAccountName"
 


### PR DESCRIPTION
This adds a public `GitHub::Ldap#logger` for clients to use. I didn't initialize to by default to STDOUT, but I can if that's something we want. cc @mtodd 
