### PR TITLE
Remove redundant attr query

### DIFF
--- a/lib/github/ldap/members/recursive.rb
+++ b/lib/github/ldap/members/recursive.rb
@@ -9,7 +9,7 @@ module GitHub
         include Filter
 
         DEFAULT_MAX_DEPTH = 9
-        ATTRS             = %w(dn member uniqueMember memberUid)
+        ATTRS             = %w(member uniqueMember memberUid)
 
         # Internal: The GitHub::Ldap object to search domains with.
         attr_reader :ldap


### PR DESCRIPTION
It's not necessary to query for the DN.

cc @jch @github/ldap 
