### PR TITLE
Bump net-ldap dependency to 0.10.0

### DIFF
--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'net-ldap', '~> 0.9.0'
+  spec.add_dependency 'net-ldap', '~> 0.10.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'ladle'


### PR DESCRIPTION
Not strictly necessary but encouraged.

cc @jch 
