### PR TITLE
Add Active Directory group filter

### DIFF
--- a/lib/github/ldap/filter.rb
+++ b/lib/github/ldap/filter.rb
@@ -3,7 +3,8 @@ module GitHub
     module Filter
       ALL_GROUPS_FILTER = Net::LDAP::Filter.eq("objectClass", "groupOfNames") |
                           Net::LDAP::Filter.eq("objectClass", "groupOfUniqueNames") |
-                          Net::LDAP::Filter.eq("objectClass", "posixGroup")
+                          Net::LDAP::Filter.eq("objectClass", "posixGroup") |
+                          Net::LDAP::Filter.eq("objectClass", "group")
 
       MEMBERSHIP_NAMES  = %w(member uniqueMember)
 


### PR DESCRIPTION
This adds an additional filter to support AD when querying for groups. We can add an integration test for this later on, but I'll include results from manual testing in a bit.

cc @mtodd 
