### PR TITLE
Subgroup Member Search strategy optimizations

### DIFF
--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -69,11 +69,11 @@ module GitHub
                 sub_dns.concat member_dns(subgroup)
               end
 
-              # give up if there's nothing else to search for
-              break if sub_dns.empty?
-
               # filter out if already searched for
               sub_dns.reject! { |dn| searched.include?(dn) }
+
+              # give up if there's nothing else to search for
+              break if sub_dns.empty?
 
               # search for subgroups
               subgroups = sub_dns.each_with_object([]) do |dn, subgroups|

--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -37,8 +37,8 @@ module GitHub
           # track groups found
           found = Hash.new
 
-          # track DNs searched for (so we don't repeat searches)
-          searched = []
+          # track all DNs searched for (so we don't repeat searches)
+          searched = Set.new
 
           # if this is a posixGroup, return members immediately (no nesting)
           uids = member_uids(group)

--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -125,7 +125,7 @@ module GitHub
             attributes: attrs,
             filter: ALL_GROUPS_FILTER
         end
-        private :find_group_by_dn
+        private :find_groups_by_dn
 
         # Internal: Fetch entries by UID.
         #

--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -77,7 +77,7 @@ module GitHub
               # search for subgroups
               subgroups = sub_dns.each_with_object([]) do |dn, subgroups|
                 subgroups.concat find_groups_by_dn(dn)
-                searched  << dn
+                searched << dn
               end
 
               # give up if there were no subgroups found

--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -94,14 +94,14 @@ module GitHub
           # entries to return
           entries  = []
 
-          # pull member DNs, discarding dupes and subgroup DNs
-          member_dns = found.values.each_with_object([]) do |group, member_dns|
+          # collect all member DNs, discarding dupes and subgroup DNs
+          members = found.values.each_with_object([]) do |group, dns|
             entries << group
-            member_dns.concat member_dns(group)
+            dns.concat member_dns(group)
           end.uniq.reject { |dn| found.key?(dn) }
 
           # wrap member DNs in Net::LDAP::Entry objects
-          entries.concat member_dns.map { |dn| Net::LDAP::Entry.new(dn) }
+          entries.concat members.map! { |dn| Net::LDAP::Entry.new(dn) }
 
           entries
         end

--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -34,9 +34,11 @@ module GitHub
         #
         # Returns Array of Net::LDAP::Entry objects.
         def perform(group)
-          found    = Hash.new
+          # track groups found
+          found = Hash.new
+
+          # track DNs searched for (so we don't repeat searches)
           searched = []
-          entries  = []
 
           # if this is a posixGroup, return members immediately (no nesting)
           uids = member_uids(group)
@@ -88,6 +90,9 @@ module GitHub
               groups = subgroups
             end
           end
+
+          # entries to return
+          entries  = []
 
           # pull member DNs, discarding dupes and subgroup DNs
           member_dns = found.values.each_with_object([]) do |group, member_dns|

--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -89,12 +89,14 @@ module GitHub
             end
           end
 
-          # take found groups and combine groups and members into list of entries
-          found.values.each do |group|
+          # pull member DNs, discarding dupes and subgroup DNs
+          member_dns = found.values.each_with_object([]) do |group, member_dns|
             entries << group
-            # just need member DNs as Net::LDAP::Entry objects
-            entries.concat member_dns(group).map { |dn| Net::LDAP::Entry.new(dn) }
-          end
+            member_dns.concat member_dns(group)
+          end.uniq.reject { |dn| found.key?(dn) }
+
+          # wrap member DNs in Net::LDAP::Entry objects
+          entries.concat member_dns.map { |dn| Net::LDAP::Entry.new(dn) }
 
           entries
         end

--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -49,11 +49,6 @@ module GitHub
           depth.times do |n|
             # find every (new, unique) member entry
             depth_subentries = entries.each_with_object([]) do |entry, depth_entries|
-              submembers = entry["member"]
-
-              # skip any members we've already found
-              submembers.reject! { |dn| found.key?(dn) }
-
               # find members of subgroup, including subgroups (N queries)
               subentries = member_entries(entry)
               next if subentries.empty?


### PR DESCRIPTION
Refactors the Recursive *Member Search* strategy to search for subgroups and then materialize members (without search).

This still performs a search for every member, but filters for group objects only. Once all of the groups have been identified (respecting the max `depth` option), we take the subgroups' members and materialize them into `Net::LDAP::Entry` objects (just wrapping the `dn`).

cc @jch 
