### PR TITLE
Expand ActiveDirectory capability support to v51 (Windows Server 2003 and above)

### DIFF
--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -19,7 +19,7 @@ module GitHub
 
     # Internal: The capability required to use ActiveDirectory features.
     # See: http://msdn.microsoft.com/en-us/library/cc223359.aspx.
-    ACTIVE_DIRECTORY_V60_OID = "1.2.840.113556.1.4.1935".freeze
+    ACTIVE_DIRECTORY_V51_OID = "1.2.840.113556.1.4.1670".freeze
 
     # Utility method to get the last operation result with a human friendly message.
     #
@@ -313,7 +313,7 @@ module GitHub
     #
     # Returns true if the host is an ActiveDirectory server, false otherwise.
     def active_directory_capability?
-      capabilities[:supportedcapabilities].include?(ACTIVE_DIRECTORY_V60_OID)
+      capabilities[:supportedcapabilities].include?(ACTIVE_DIRECTORY_V51_OID)
     end
     private :active_directory_capability?
   end

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -19,7 +19,7 @@ module GitHub
 
     # Internal: The capability required to use ActiveDirectory features.
     # See: http://msdn.microsoft.com/en-us/library/cc223359.aspx.
-    ACTIVE_DIRECTORY_V61_R2_OID = "1.2.840.113556.1.4.2080".freeze
+    ACTIVE_DIRECTORY_V60_OID = "1.2.840.113556.1.4.1935".freeze
 
     # Utility method to get the last operation result with a human friendly message.
     #
@@ -313,7 +313,7 @@ module GitHub
     #
     # Returns true if the host is an ActiveDirectory server, false otherwise.
     def active_directory_capability?
-      capabilities[:supportedcapabilities].include?(ACTIVE_DIRECTORY_V61_R2_OID)
+      capabilities[:supportedcapabilities].include?(ACTIVE_DIRECTORY_V60_OID)
     end
     private :active_directory_capability?
   end

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -80,7 +80,7 @@ module GitHubLdapTestCases
 
   def test_search_strategy_detects_active_directory
     caps = Net::LDAP::Entry.new
-    caps[:supportedcapabilities] = [GitHub::Ldap::ACTIVE_DIRECTORY_V60_OID]
+    caps[:supportedcapabilities] = [GitHub::Ldap::ACTIVE_DIRECTORY_V51_OID]
 
     @ldap.stub :capabilities, caps do
       @ldap.configure_search_strategy :detect

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -80,7 +80,7 @@ module GitHubLdapTestCases
 
   def test_search_strategy_detects_active_directory
     caps = Net::LDAP::Entry.new
-    caps[:supportedcapabilities] = [GitHub::Ldap::ACTIVE_DIRECTORY_V61_R2_OID]
+    caps[:supportedcapabilities] = [GitHub::Ldap::ACTIVE_DIRECTORY_V60_OID]
 
     @ldap.stub :capabilities, caps do
       @ldap.configure_search_strategy :detect


### PR DESCRIPTION
This expands support for ActiveDirectory capabilities to Windows Server 2003 and above, instead of only Windows Server 2008 R2 and above.

NOTE: This assumes that anyone running 2003 will have Service Pack 1 installed at a minimum (notably because SP1 is end-of-lifed for support already). Unfortunately, there's not a documented way to detect that SP1 was installed reliably.

cc @jatoben @johnyerhot @buckelij @github/ldap 
