### PR TITLE
Compare AD DNs case-insensitively when checking group membership

### DIFF
--- a/lib/github/ldap/membership_validators/active_directory.rb
+++ b/lib/github/ldap/membership_validators/active_directory.rb
@@ -31,7 +31,8 @@ module GitHub
             attributes: ATTRS
 
           # membership validated if entry was matched and returned as a result
-          matched.map(&:dn).include?(entry.dn)
+          # Active Directory DNs are case-insensitive
+          matched.map { |m| m.dn.downcase }.include?(entry.dn.downcase)
         end
 
         # Internal: Constructs a membership filter using the "in chain"

--- a/test/membership_validators/active_directory_test.rb
+++ b/test/membership_validators/active_directory_test.rb
@@ -123,4 +123,13 @@ class GitHubLdapActiveDirectoryMembershipValidatorsIntegrationTest < GitHub::Lda
     validator = make_validator(%w(posix-group1))
     assert validator.perform(@entry)
   end
+
+  def test_validates_user_in_group_with_differently_cased_dn
+    validator = make_validator(%w(all-users))
+    @entry[:dn].map(&:upcase!)
+    assert validator.perform(@entry)
+
+    @entry[:dn].map(&:downcase!)
+    assert validator.perform(@entry)
+  end
 end


### PR DESCRIPTION
Active Directory is case-insensitive but case-preserving for most attributes, including DNs.

When binding, the DN will be returned in the entry with the same case as you originally provided, regardless of how the DN is actually stored. But because the Active Directory group membership validator uses a case-sensitive comparison, it excludes the user from groups they should belong to:

```ruby
domain.user?('user1').dn
=> "CN=User 1,CN=Users,DC=example,DC=com"

entry = strategy.domain('cn=user 1,cn=users,dc=example,dc=com').bind
entry.dn
=> "cn=user 1,cn=users,dc=example,dc=com"

groups = domain.groups(['all-users'])
groups.first.member
=> ["CN=User 1,CN=Users,DC=example,DC=com"]

validator = strategy.membership_validator.new(strategy, groups)
validator.perform(entry)
=> false
```

This PR makes the AD membership validator case-insensitive when comparing DNs.

/cc @github/enterprise-support @github/ldap @mtodd @shayfrendt 