### PR TITLE
Release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# v1.8.2
+
+* Ignore case when comparing ActiveDirectory DNs [#82](https://github.com/github/github-ldap/pull/82)
+
 # v1.8.1
 
 * Expand supported ActiveDirectory capabilities to include Windows Server 2003 [#80](https://github.com/github/github-ldap/pull/80)

--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "github-ldap"
-  spec.version       = "1.8.1"
+  spec.version       = "1.8.2"
   spec.authors       = ["David Calavera", "Matt Todd"]
   spec.email         = ["david.calavera@gmail.com", "chiology@gmail.com"]
   spec.description   = %q{LDAP authentication for humans}


### PR DESCRIPTION
Fixes the AD DN case comparisons patched in #82.

cc @jatoben 
