### PR TITLE
Bump net-ldap dependency to v0.11.x

### DIFF
--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'net-ldap', '~> 0.10.0'
+  spec.add_dependency 'net-ldap', '~> 0.11.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'ladle'

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class FilterTest < Minitest::Test
+class FilterTest < GitHub::Ldap::Test
   class Subject
     include GitHub::Ldap::Filter
     def initialize(ldap)
@@ -16,7 +16,7 @@ class FilterTest < Minitest::Test
   end
 
   def setup
-    @ldap    = GitHub::Ldap.new(:uid => 'uid')
+    @ldap    = GitHub::Ldap.new(options.merge(:uid => 'uid'))
     @subject = Subject.new(@ldap)
     @me      = 'uid=calavera,dc=github,dc=com'
     @uid     = "calavera"


### PR DESCRIPTION
Pulls in changes documented in https://github.com/ruby-ldap/ruby-net-ldap/pull/189.

cc @jch @shayfrendt 
