### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# v1.9.0
+
+* Update net-ldap dependency to `~> 0.11.0` [#84](https://github.com/github/github-ldap/pull/84)
+
 # v1.8.2
 
 * Ignore case when comparing ActiveDirectory DNs [#82](https://github.com/github/github-ldap/pull/82)

--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "github-ldap"
-  spec.version       = "1.8.2"
+  spec.version       = "1.9.0"
   spec.authors       = ["David Calavera", "Matt Todd"]
   spec.email         = ["david.calavera@gmail.com", "chiology@gmail.com"]
   spec.description   = %q{LDAP authentication for humans}


### PR DESCRIPTION
* Update net-ldap dependency to `~> 0.11.0` [#84](https://github.com/github/github-ldap/pull/84)

cc @jch @shayfrendt 
