### PR TITLE
add support for ldap referral chasing

### DIFF
--- a/lib/github/ldap/member_search/recursive.rb
+++ b/lib/github/ldap/member_search/recursive.rb
@@ -123,7 +123,8 @@ module GitHub
             base: dn,
             scope: Net::LDAP::SearchScope_BaseObject,
             attributes: attrs,
-            filter: ALL_GROUPS_FILTER
+            filter: ALL_GROUPS_FILTER,
+            return_referrals: true
         end
         private :find_groups_by_dn
 
@@ -133,7 +134,7 @@ module GitHub
         def entries_by_uid(members)
           filter = members.map { |uid| Net::LDAP::Filter.eq(ldap.uid, uid) }.reduce(:|)
           domains.each_with_object([]) do |domain, entries|
-            entries.concat domain.search(filter: filter, attributes: attrs)
+            entries.concat domain.search(filter: filter, attributes: attrs, return_referrals: true)
           end.compact
         end
         private :entries_by_uid

--- a/lib/github/ldap/membership_validators/recursive.rb
+++ b/lib/github/ldap/membership_validators/recursive.rb
@@ -51,7 +51,7 @@ module GitHub
 
           domains.each do |domain|
             # find groups entry is an immediate member of
-            membership = domain.search(filter: member_filter(entry), attributes: ATTRS)
+            membership = domain.search(filter: member_filter(entry), attributes: ATTRS, return_referrals: true)
 
             # success if any of these groups match the restricted auth groups
             return true if membership.any? { |entry| group_dns.include?(entry.dn) }
@@ -62,7 +62,7 @@ module GitHub
             # recurse to at most `depth`
             (depth_override || depth).times do |n|
               # find groups whose members include membership groups
-              membership = domain.search(filter: membership_filter(membership), attributes: ATTRS)
+              membership = domain.search(filter: membership_filter(membership), attributes: ATTRS, return_referrals: true)
 
               # success if any of these groups match the restricted auth groups
               return true if membership.any? { |entry| group_dns.include?(entry.dn) }


### PR DESCRIPTION
Add ```search_referrals``` flag to Net::LDAP calls, filter out ```search_referrals``` and query the returned server with the same credentials & settings like the initial one. Result is a merged list with the result of all servers.