### PR TITLE
Forward search from GC to obtain non universal groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
   - TESTENV=openldap
   - TESTENV=apacheds
 
+before_install:
+  - gem update bundler
+
 install:
   - if [ "$TESTENV" = "openldap" ]; then ./script/install-openldap; fi
   - bundle install


### PR DESCRIPTION
If a Global Catalog is used as LDAP endpoint (3268 | 3269) this implementation will query the GC for all availabe AD server within the forst and forward the search context to these servers. It enables all global and local groups to become visible by the LDAP sync mechanism of GHE.

__Testing__
* Setup an AD forest as described:
  * https://www.youtube.com/watch?v=M4kNJVCnAok
  * https://www.youtube.com/watch?v=b1z48OdpovY
  * https://www.youtube.com/watch?v=RpXZPd6ttGg
* Create some users and groups on all servers
  * Make sure groups are marked local or global but not universal
* Within the management console of GHE add all root basedn of your ADs as Domain bases
* Connect GHE via port 3268 to any AD server