### PR TITLE
Support Active Directory Forest searches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
   - TESTENV=openldap
   - TESTENV=apacheds
 
+before_install:
+  - gem update bundler
+
 install:
   - if [ "$TESTENV" = "openldap" ]; then ./script/install-openldap; fi
   - bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 group :test, :development do
   gem "byebug", :platforms => [:mri_20, :mri_21]
+  gem "mocha"
 end

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -271,7 +271,7 @@ module GitHub
     #
     def configure_entry_search_strategy(use_forest_search)
       @entry_search_strategy = if use_forest_search && active_directory_capability? && capabilities[:configurationnamingcontext].any?
-        @entry_search_strategy = GitHub::Ldap::ForestSearch.new(@connection)
+        @entry_search_strategy = GitHub::Ldap::ForestSearch.new(@connection, capabilities[:configurationnamingcontext].first)
       else
         @entry_search_strategy = @connection
       end

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -261,13 +261,18 @@ module GitHub
       configure_member_search_strategy(strategy)
     end
 
+    # Internal: Configure the entry search strategy.
+    #
+    # If the user has configured GHE to use forest searches AND we have an active
+    # Directory instance that has the right capabilities, use a ForestSearch
+    # strategy. Otherwise, the entry search strategy is simple the existing LDAP
+    # connection object.
+    #
     def configure_entry_search_strategy(use_forest_search)
-      @entry_search_strategy = begin
-        if use_forest_search && active_directory_capability? &&  capabilities[:configurationnamingcontext].any?
-          @entry_search_strategy = GitHub::Ldap::ForestSearch.new(@connection)
-        else
-          @entry_search_strategy = @connection
-        end
+      @entry_search_strategy = if use_forest_search && active_directory_capability? && capabilities[:configurationnamingcontext].any?
+        @entry_search_strategy = GitHub::Ldap::ForestSearch.new(@connection)
+      else
+        @entry_search_strategy = @connection
       end
     end
 
@@ -321,7 +326,6 @@ module GitHub
           end
         end
     end
-
 
     # Internal: Detect whether the LDAP host is an ActiveDirectory server.
     #

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -9,6 +9,7 @@ require 'github/ldap/virtual_group'
 require 'github/ldap/virtual_attributes'
 require 'github/ldap/instrumentation'
 require 'github/ldap/member_search'
+require 'github/ldap/forest_search'
 require 'github/ldap/membership_validators'
 
 module GitHub

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -100,6 +100,9 @@ module GitHub
 
       # enables instrumenting queries
       @instrumentation_service = options[:instrumentation_service]
+
+      # active directory forest
+      @forest = get_domain_forest(options[:search_forest])
     end
 
     # Public - Whether membership checks should recurse into nested groups when
@@ -180,16 +183,36 @@ module GitHub
       instrument "search.github_ldap", options.dup do |payload|
         result =
           if options[:base]
-            @connection.search(options, &block)
+            forest_search(options, &block)
           else
             search_domains.each_with_object([]) do |base, result|
-              rs = @connection.search(options.merge(:base => base), &block)
+              rs = forest_search(options.merge(:base => base), &block)
               result.concat Array(rs) unless rs == false
             end
           end
 
         return [] if result == false
         Array(result)
+      end
+    end
+
+    # Internal: Search within a ldap forest
+    #
+    # Returns an Array of Net::LDAP::Entry.
+    def forest_search(options, &block)
+      instrument "forest_search.github_ldap" do |payload|
+        result =
+          if @forest.empty?
+            @connection.search(options, &block)
+          else
+            @forest.each_with_object([]) do |(rootdn, server), res|
+              if options[:base].end_with?(rootdn)
+                rs = server.search(options, &block)
+                res.concat Array(rs) unless rs == false
+              end
+            end
+          end
+        return result
       end
     end
 
@@ -201,7 +224,8 @@ module GitHub
       @capabilities ||=
         instrument "capabilities.github_ldap" do |payload|
           begin
-            @connection.search_root_dse
+            rs = @connection.search(:ignore_server_caps => true, :base => "", :scope => Net::LDAP::SearchScope_BaseObject)
+            (rs and rs.first)
           rescue Net::LDAP::LdapError => error
             payload[:error] = error
             # stubbed result
@@ -305,6 +329,37 @@ module GitHub
             GitHub::Ldap::MemberSearch::Recursive
           end
         end
+    end
+
+    # Internal: Queries configuration for available domains
+    #
+    # Membership of local or global groups need to be evaluated by contacting referral Donmain Controllers
+    #
+    # Returns all Domain Controllers within the forest
+    def get_domain_forest(search_forest)
+      instrument "get_domain_forest.github_ldap" do |payload|
+
+        # if we are talking to an active directory
+        if search_forest and active_directory_capability? and capabilities[:configurationnamingcontext].any?
+          domains = @connection.search(
+            base: capabilities[:configurationnamingcontext].first,
+            search_referrals: true,
+            filter: Net::LDAP::Filter.eq("nETBIOSName", "*")
+          )
+          return domains.each_with_object({}) do |server, result|
+            if server[:ncname].any? and server[:dnsroot].any?
+              result[server[:ncname].first] = Net::LDAP.new({
+                host: server[:dnsroot].first,
+                port: @connection.instance_variable_get(:@encryption)? 636 : 389,
+                auth: @connection.instance_variable_get(:@auth),
+                encryption: @connection.instance_variable_get(:@encryption),
+                instrumentation_service: @connection.instance_variable_get(:@instrumentation_service)
+              })
+            end
+          end
+        end
+        return {}
+      end
     end
 
     # Internal: Detect whether the LDAP host is an ActiveDirectory server.

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -85,7 +85,7 @@ module GitHub
       end
 
       configure_virtual_attributes(options[:virtual_attributes])
-      configure_entry_search_strategy(options[:search_forest])
+      configure_entry_search_strategy(options[:use_forest_search])
 
       # enable fallback recursive group search unless option is false
       @recursive_group_search_fallback = (options[:recursive_group_search_fallback] != false)

--- a/lib/github/ldap/forest_search.rb
+++ b/lib/github/ldap/forest_search.rb
@@ -42,21 +42,24 @@ module GitHub
       def get_domain_forest
         instrument "get_domain_forest.github_ldap" do |payload|
           domains = @connection.search(
-            base: capabilities[:configurationnamingcontext].first,
+            base: naming_context,
             search_referrals: true,
             filter: Net::LDAP::Filter.eq("nETBIOSName", "*")
           )
-          return domains.each_with_object({}) do |server, result|
-            if server[:ncname].any? and server[:dnsroot].any?
-              result[server[:ncname].first] = Net::LDAP.new({
-                host: server[:dnsroot].first,
-                port: @connection.instance_variable_get(:@encryption)? 636 : 389,
-                auth: @connection.instance_variable_get(:@auth),
-                encryption: @connection.instance_variable_get(:@encryption),
-                instrumentation_service: @connection.instance_variable_get(:@instrumentation_service)
-              })
+          unless domains.nil?
+            return domains.each_with_object({}) do |server, result|
+              if server[:ncname].any? and server[:dnsroot].any?
+                result[server[:ncname].first] = Net::LDAP.new({
+                  host: server[:dnsroot].first,
+                  port: @connection.instance_variable_get(:@encryption)? 636 : 389,
+                  auth: @connection.instance_variable_get(:@auth),
+                  encryption: @connection.instance_variable_get(:@encryption),
+                  instrumentation_service: @connection.instance_variable_get(:@instrumentation_service)
+                })
+              end
             end
           end
+          return {}
         end
       end
 

--- a/lib/github/ldap/forest_search.rb
+++ b/lib/github/ldap/forest_search.rb
@@ -26,6 +26,8 @@ module GitHub
 
       private
 
+      attr_reader :connection
+
       # Internal: Queries configuration for available domains
       #
       # Membership of local or global groups need to be evaluated by contacting referral Donmain Controllers
@@ -51,7 +53,7 @@ module GitHub
           end
         end
       end
-      attr_reader :connection
+
     end
   end
 end

--- a/lib/github/ldap/forest_search.rb
+++ b/lib/github/ldap/forest_search.rb
@@ -22,8 +22,8 @@ module GitHub
 
       # Search over all domain controllers in the ActiveDirectory forest.
       #
-      # options: options hash passed in from GitHub::Ldap#search
-      # &block:  optional block passed in from GitHub::Ldap#search
+      # options: is a hash with the same options that Net::LDAP::Connection#search supports.
+      # block: is an optional block to pass to the search.
       #
       # If no domain controllers are found in the forest, fall back on searching
       # the main GitHub::Ldap object in @connection.

--- a/lib/github/ldap/forest_search.rb
+++ b/lib/github/ldap/forest_search.rb
@@ -20,10 +20,10 @@ module GitHub
               @connection.search(options, &block)
             else
               @forest.each_with_object([]) do |(rootdn, server), res|
-              if options[:base].end_with?(rootdn)
-                rs = server.search(options, &block)
-                res.concat Array(rs) unless rs == false
-              end
+                if options[:base].end_with?(rootdn)
+                  rs = server.search(options, &block)
+                  res.concat Array(rs) unless rs == false
+                end
               end
             end
           return result

--- a/lib/github/ldap/forest_search.rb
+++ b/lib/github/ldap/forest_search.rb
@@ -1,0 +1,57 @@
+module GitHub
+  class Ldap
+    class ForestSearch
+
+      def initialize(connection)
+        @connection = connection
+        @forest = get_domain_forest
+      end
+
+      def search(options, &block)
+        instrument "forest_search.github_ldap" do |payload|
+          result =
+            if @forest.empty?
+              @connection.search(options, &block)
+            else
+              @forest.each_with_object([]) do |(rootdn, server), res|
+              if options[:base].end_with?(rootdn)
+                rs = server.search(options, &block)
+                res.concat Array(rs) unless rs == false
+              end
+              end
+            end
+          return result
+        end
+      end
+
+      private
+
+      # Internal: Queries configuration for available domains
+      #
+      # Membership of local or global groups need to be evaluated by contacting referral Donmain Controllers
+      #
+      # Returns all Domain Controllers within the forest
+      def get_domain_forest
+        instrument "get_domain_forest.github_ldap" do |payload|
+          domains = @connection.search(
+            base: capabilities[:configurationnamingcontext].first,
+            search_referrals: true,
+            filter: Net::LDAP::Filter.eq("nETBIOSName", "*")
+          )
+          return domains.each_with_object({}) do |server, result|
+            if server[:ncname].any? and server[:dnsroot].any?
+              result[server[:ncname].first] = Net::LDAP.new({
+                host: server[:dnsroot].first,
+                port: @connection.instance_variable_get(:@encryption)? 636 : 389,
+                auth: @connection.instance_variable_get(:@auth),
+                encryption: @connection.instance_variable_get(:@encryption),
+                instrumentation_service: @connection.instance_variable_get(:@instrumentation_service)
+              })
+            end
+          end
+        end
+      end
+      attr_reader :connection
+    end
+  end
+end

--- a/lib/github/ldap/forest_search.rb
+++ b/lib/github/ldap/forest_search.rb
@@ -1,8 +1,14 @@
+require 'github/ldap/instrumentation'
+
 module GitHub
   class Ldap
+    # For ActiveDirectory environments that have a forest with multiple domain controllers,
+    # this strategy class allows for entry searches across all domains in that forest.
     class ForestSearch
+      include Instrumentation
 
-      def initialize(connection)
+      def initialize(connection, naming_context)
+        @naming_context = naming_context
         @connection = connection
         @forest = get_domain_forest
       end
@@ -26,7 +32,7 @@ module GitHub
 
       private
 
-      attr_reader :connection
+      attr_reader :connection, :naming_context
 
       # Internal: Queries configuration for available domains
       #

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -19,4 +19,13 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
     @connection.expects(:search)
     @forest_search.search({})
   end
+
+  def test_uses_connection_search_when_domains_nil
+    # First search returns nil
+    @connection.expects(:search).returns(nil)
+    # Since the forest is empty, should fall back on the base connection
+    @connection.expects(:search)
+    @forest_search.search({})
+  end
+
 end

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -53,4 +53,23 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
     @forest_search.search({:base => base})
   end
 
+  def test_returns_concatenated_search_results_from_forest
+    mock_domains = Object.new
+    mock_domain_controller = Object.new
+
+    mock_dc_connection1 = Object.new
+    mock_dc_connection2 = Object.new
+    rootdn = "DC=ad,DC=ghe,DC=local"
+    forest = [[rootdn, mock_dc_connection1],[rootdn, mock_dc_connection2]]
+
+    @connection.expects(:search).returns(mock_domains)
+    mock_domains.expects(:each_with_object).returns(forest)
+
+    mock_dc_connection1.expects(:search).returns(["entry1"])
+    mock_dc_connection2.expects(:search).returns(["entry2"])
+    base = "CN=user1,CN=Users,DC=ad,DC=ghe,DC=local"
+    results = @forest_search.search({:base => base})
+    assert_equal results, ["entry1", "entry2"]
+  end
+
 end

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -72,4 +72,24 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
     assert_equal results, ["entry1", "entry2"]
   end
 
+  def test_does_not_search_from_different_rootdn
+    mock_domains = Object.new
+    mock_domain_controller = Object.new
+
+    mock_dc_connection1 = Object.new
+    mock_dc_connection2 = Object.new
+    forest = {"DC=ad,DC=ghe,DC=local" => mock_dc_connection1,
+              "DC=fu,DC=bar,DC=local" => mock_dc_connection2}
+
+    @connection.expects(:search).returns(mock_domains)
+    mock_domains.expects(:each_with_object).returns(forest)
+
+    mock_dc_connection1.expects(:search).returns(["entry1"])
+    mock_dc_connection2.expects(:search).never
+
+    base = "CN=user1,CN=Users,DC=ad,DC=ghe,DC=local"
+    results = @forest_search.search({:base => base})
+    assert_equal results, ["entry1"]
+  end
+
 end

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -12,7 +12,11 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
     @forest_search = GitHub::Ldap::ForestSearch.new(@connection, configuration_naming_context)
   end
 
-  def test_search
+  def test_uses_connection_search_when_no_forest_present
+    # First search returns an empty Hash of domain controllers
+    @connection.expects(:search).returns({})
+    # Since the forest is empty, should fall back on the base connection
+    @connection.expects(:search)
     @forest_search.search({})
     assert true
   end

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -18,6 +18,5 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
     # Since the forest is empty, should fall back on the base connection
     @connection.expects(:search)
     @forest_search.search({})
-    assert true
   end
 end

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -1,0 +1,18 @@
+require_relative 'test_helper'
+
+class GitHubLdapForestSearchTest < GitHub::Ldap::Test
+  def setup
+    @connection = Net::LDAP.new({
+      host: options[:host],
+      port: options[:port],
+      instrumentation_service: options[:instrumentation_service]
+    })
+    #@connection.stub(:search, {}, ['search-forest'])
+    @forest_search = GitHub::Ldap::ForestSearch.new(@connection, "naming")
+  end
+
+  def test_search
+    @forest_search.search({})
+    assert true
+  end
+end

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -8,8 +8,8 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
       port: options[:port],
       instrumentation_service: options[:instrumentation_service]
     })
-    #@connection.stub(:search, {}, ['search-forest'])
-    @forest_search = GitHub::Ldap::ForestSearch.new(@connection, "naming")
+    configuration_naming_context = "CN=Configuration,DC=ad,DC=ghe,DC=local"
+    @forest_search = GitHub::Ldap::ForestSearch.new(@connection, configuration_naming_context)
   end
 
   def test_search

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -92,7 +92,7 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
     assert_equal results, ["entry1"]
   end
 
-  def test_searches_domain_controllers_from_differet_domains
+  def test_searches_domain_controllers_from_different_domains
     server1 = {:ncname => ["DC=ghe,DC=local"], :dnsroot => ["ghe.local"]}
     server2 = {:ncname => ["DC=ad,DC=ghe,DC=local"], :dnsroot => ["ad.ghe.local"]}
     server3 = {:ncname => ["DC=eng,DC=ad,DC=ghe,DC=local"], :dnsroot => ["eng.ad.ghe.local"]}

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -1,4 +1,5 @@
 require_relative 'test_helper'
+require 'mocha/mini_test'
 
 class GitHubLdapForestSearchTest < GitHub::Ldap::Test
   def setup

--- a/test/forest_search_test.rb
+++ b/test/forest_search_test.rb
@@ -37,7 +37,6 @@ class GitHubLdapForestSearchTest < GitHub::Ldap::Test
     mock_dc_connection2 = Object.new
     rootdn = "DC=ad,DC=ghe,DC=local"
     # Create a mock forest that contains the two mock DCs
-    # This assumes a single-l
     forest = [[rootdn, mock_dc_connection1],[rootdn, mock_dc_connection2]]
 
     # First search returns the Hash of domain controllers


### PR DESCRIPTION
Creating a new PR to continue the work started by @timmjd on https://github.com/github/github-ldap/pull/89. We can move forward on this with an internal branch instead of an external fork.

TODO: 
- [x] Unit tests
- [x] Test with a regular single-DC environment.
- [x] Test against an internal AD forest environment
- [x] Test against OpenLDAP
- [ ] Add configuration flag in github/github to enable feature https://github.com/github/github/pull/58154
- [ ] Integration tests if possible (working on Vagrant + PowerShell script to build AD forest)

/cc @gnawhleinad @mtodd @jch 
/cc @jatoben @lildude for thoughts as well since you were involved in the [original discussion](https://github.com/github/platform-iam/issues/6)