### PR TITLE
Bump net-ldap to 0.15.0

### DIFF
--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'net-ldap', '~> 0.11.0'
+  spec.add_dependency 'net-ldap', '~> 0.15.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'ladle'


### PR DESCRIPTION
Changes since 0.11.0 according to [net-ldap changelog](https://github.com/ruby-ldap/ruby-net-ldap/blob/master/History.rdoc#netldap-0150):

```
Net::LDAP 0.15.0

Respect connect_timeout when establishing SSL connections #273

Net::LDAP 0.14.0

Normalize the encryption parameter passed to the LDAP constructor #264

Update Docs: Net::LDAP now requires ruby >= 2 #261

fix symbol proc #255

fix trailing commas #256

fix deprecated hash methods #254

fix space after comma #253

fix space inside brackets #252

Rubocop style fixes #249

Lazy initialize Net::LDAP::Connection's internal socket #235

Support for rfc3062 Password Modify, closes #163 #178

Net::LDAP 0.13.0

Avoid this release for because of an backwards incompatibility in how encryption is initialized github.com/ruby-ldap/ruby-net-ldap/pull/264. We did not yank it because people have already worked around it.

Set a connect_timeout for the creation of a socket #243

Update bundler before installing gems with bundler #245

Net::LDAP#encryption accepts string #239

Adds correct UTF-8 encoding to Net::BER::BerIdentifiedString #242

Remove 2.3.0-preview since ruby-head already is included #241

Drop support for ruby 1.9.3 #240

Fixed capitalization of StartTLSError #234

Net::LDAP 0.12.1

Whitespace formatting cleanup #236

Set operation result if LDAP server is not accessible #232

Net::LDAP 0.12.0

DRY up connection handling logic #224

Define auth adapters #226

add slash to attribute value filter #225

Add the ability to provide a list of hosts for a connection #223

Specify the port of LDAP server by giving INTEGRATION_PORT #221

Correctly set BerIdentifiedString values to UTF-8 #212

Raise Net::LDAP::ConnectionRefusedError when new connection is refused. #213

obscure auth password upon #inspect, added test, closes #216 #217

Fixing incorrect error class name #207

Travis update #205

Remove obsolete rbx-19mode from Travis #204

mv “sudo” from script/install-openldap to .travis.yml #199

Remove meaningless shebang #200

Fix Travis CI build #202

README.rdoc: fix travis link #195

```