### PR TITLE
Support querying Active Directory Global Catalog

### DIFF
--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -303,7 +303,7 @@ module GitHub
     #            using Active Directory's Global Catalog
     #            functionality.
     def configure_user_search_strategy(strategy)
-      @user_search_strategy = begin
+      @user_search_strategy =
         case strategy.to_s
         when "default"
           GitHub::Ldap::UserSearch::Default.new(self)
@@ -312,7 +312,6 @@ module GitHub
         else
           GitHub::Ldap::UserSearch::Default.new(self)
         end
-      end
     end
 
     # Internal: Configure the member search strategy.


### PR DESCRIPTION
For Active Directory deployments, in some cases, like authentication or simple entry searches, it will make sense to search the [Global Catalog](https://technet.microsoft.com/en-us/library/cc728188(v=ws.10).aspx) rather than the default configured Domain Controller. This PR will initialize a Global Catalog connection object when requested, and provides an interface to directly query the catalog. `GitHub::Ldap::Domain` will now use the Global Catalog for `user?`, if the server is an Active Directory, and the configured Domain Controller is a Global Catalog, or if the user has provided global catalog settings in the initializer options.

##### TODO:
- [x] Initialize global catalog connection
- [x] Make interface to query the catalog
- [x] Have `GitHub::Ldap::Domain#user?` use the catalog if server is AD & catalog is present
- [x] Allow user to provide Global Catalog host & port, otherwise default to the given Domain Controller

This begins an alternative approach to https://github.com/github/github-ldap/pull/91. To fully replace that, we'll have to also implement referral chasing to be able to search for groups that aren't configured to be Active Directory "universal" groups. I'll do that in a separate PR.

/cc @mtodd @jch @sbryant @lildude @timmjd
/cc @github/ldap