### PR TITLE
Add support for passing a list of ldap servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ There are a few configuration options required to use this adapter:
 
 * host: is the host address where the ldap server lives.
 * port: is the port where the ldap server lives.
+* hosts: (optional) an enumerable of pairs of hosts and corresponding ports with which to attempt opening connections (default [[host, port]]). Overrides host and port if set.
 * encryption: is the encryption protocol, disabled by default. The valid options are `ssl` and `tls`.
 * uid: is the field name in the ldap server used to authenticate your users, in ActiveDirectory this is `sAMAccountName`.
 

--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "github-ldap"
-  spec.version       = "1.9.0"
+  spec.version       = "1.9.1"
   spec.authors       = ["David Calavera", "Matt Todd"]
   spec.email         = ["david.calavera@gmail.com", "chiology@gmail.com"]
   spec.description   = %q{LDAP authentication for humans}

--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'net-ldap', '~> 0.11.0'
+  spec.add_dependency 'net-ldap', '~> 0.14.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'ladle'

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -50,6 +50,9 @@ module GitHub
     #
     # host: required string ldap server host address
     # port: required string or number ldap server port
+    # hosts: an enumerable of pairs of hosts and corresponding ports with
+    #   which to attempt opening connections (default [[host, port]]). Overrides
+    #   host and port if set.
     # encryption: optional string. `ssl` or `tls`. nil by default
     # admin_user: optional string ldap administrator user dn for authentication
     # admin_password: optional string ldap administrator user password
@@ -72,6 +75,7 @@ module GitHub
       @connection = Net::LDAP.new({
         host: options[:host],
         port: options[:port],
+        hosts: options[:hosts],
         instrumentation_service: options[:instrumentation_service]
       })
 

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -9,6 +9,21 @@ module GitHubLdapTestCases
     assert @ldap.test_connection, "Ldap connection expected to succeed"
   end
 
+  def test_connection_with_list_of_hosts_with_one_valid_host
+    ldap = GitHub::Ldap.new(options.merge(hosts: [["localhost", 3897]]))
+    assert ldap.test_connection, "Ldap connection expected to succeed"
+  end
+
+  def test_connection_with_list_of_hosts_with_first_valid
+    ldap = GitHub::Ldap.new(options.merge(hosts: [["localhost", 3897], ["invalid.local", 3897]]))
+    assert ldap.test_connection, "Ldap connection expected to succeed"
+  end
+
+  def test_connection_with_list_of_hosts_with_first_invalid
+    ldap = GitHub::Ldap.new(options.merge(hosts: [["invalid.local", 3897], ["localhost", 3897]]))
+    assert ldap.test_connection, "Ldap connection expected to succeed"
+  end
+
   def test_simple_tls
     assert_equal :simple_tls, @ldap.check_encryption(:ssl)
     assert_equal :simple_tls, @ldap.check_encryption('SSL')

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -10,17 +10,17 @@ module GitHubLdapTestCases
   end
 
   def test_connection_with_list_of_hosts_with_one_valid_host
-    ldap = GitHub::Ldap.new(options.merge(hosts: [["localhost", 3897]]))
+    ldap = GitHub::Ldap.new(options.merge(hosts: [["localhost", options[:port]]]))
     assert ldap.test_connection, "Ldap connection expected to succeed"
   end
 
   def test_connection_with_list_of_hosts_with_first_valid
-    ldap = GitHub::Ldap.new(options.merge(hosts: [["localhost", 3897], ["invalid.local", 3897]]))
+    ldap = GitHub::Ldap.new(options.merge(hosts: [["localhost", options[:port]], ["invalid.local", options[:port]]]))
     assert ldap.test_connection, "Ldap connection expected to succeed"
   end
 
   def test_connection_with_list_of_hosts_with_first_invalid
-    ldap = GitHub::Ldap.new(options.merge(hosts: [["invalid.local", 3897], ["localhost", 3897]]))
+    ldap = GitHub::Ldap.new(options.merge(hosts: [["invalid.local", options[:port]], ["localhost", options[:port]]]))
     assert ldap.test_connection, "Ldap connection expected to succeed"
   end
 


### PR DESCRIPTION
https://github.com/ruby-ldap/ruby-net-ldap/pull/223 introduced the ability to configure net-ldap to use an array of hostnames and ports, with basic failover support.

This PR adds the ability to pass this same array to net-ldap via github-ldap so this basic failover functionality can be used by github-ldap related projects too.

/cc @jch @mtodd @sbryant 