### PR TITLE
Enable TLS validation

### DIFF
--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -243,7 +243,7 @@ module GitHub
     def check_encryption(encryption, validate = false)
       return unless encryption
 
-      tls_options = { verify_mode: (validate == true ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE }
+      tls_options = { verify_mode: (validate == true ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE) }
       case encryption.downcase.to_sym
       when :ssl, :simple_tls
         { method: :simple_tls, tls_options: tls_options }

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -243,7 +243,7 @@ module GitHub
     def check_encryption(encryption, validate = false)
       return unless encryption
 
-      tls_options = validate == true ? OpenSSL::SSL::VERIFY_PEER : {}
+      tls_options = { verify_mode: (validate == true ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE }
       case encryption.downcase.to_sym
       when :ssl, :simple_tls
         { method: :simple_tls, tls_options: tls_options }

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -245,6 +245,7 @@ module GitHub
     def check_encryption(encryption, tls_options = {})
       return unless encryption
 
+      tls_options ||= {}
       case encryption.downcase.to_sym
       when :ssl, :simple_tls
         { method: :simple_tls, tls_options: tls_options }

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -65,7 +65,9 @@ module GitHub
     #   which to attempt opening connections (default [[host, port]]). Overrides
     #   host and port if set.
     # encryption: optional string. `ssl` or `tls`. nil by default
-    # tls_options: optional hash with TLS options for encrypted connections. Empty by default.
+    # tls_options: optional hash with TLS options for encrypted connections.
+    #   Empty by default. See http://ruby-doc.org/stdlib/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html
+    #   for available values
     # admin_user: optional string ldap administrator user dn for authentication
     # admin_password: optional string ldap administrator user password
     #
@@ -237,7 +239,7 @@ module GitHub
     # Internal - Determine whether to use encryption or not.
     #
     # encryption: is the encryption method, either 'ssl', 'tls', 'simple_tls' or 'start_tls'.
-    # validate: is true to enable certificate validation
+    # tls_options: is the options hash for tls encryption method
     #
     # Returns the real encryption type.
     def check_encryption(encryption, tls_options = {})

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -25,15 +25,30 @@ module GitHubLdapTestCases
   end
 
   def test_simple_tls
-    assert_equal :simple_tls, @ldap.check_encryption(:ssl)
-    assert_equal :simple_tls, @ldap.check_encryption('SSL')
-    assert_equal :simple_tls, @ldap.check_encryption(:simple_tls)
+    expected = { method: :simple_tls, tls_options: {} }
+    assert_equal expected, @ldap.check_encryption(:ssl)
+    assert_equal expected, @ldap.check_encryption('SSL')
+    assert_equal expected, @ldap.check_encryption(:simple_tls)
   end
 
   def test_start_tls
-    assert_equal :start_tls, @ldap.check_encryption(:tls)
-    assert_equal :start_tls, @ldap.check_encryption('TLS')
-    assert_equal :start_tls, @ldap.check_encryption(:start_tls)
+    expected = { method: :start_tls, tls_options: {} }
+    assert_equal expected, @ldap.check_encryption(:tls)
+    assert_equal expected, @ldap.check_encryption('TLS')
+    assert_equal expected, @ldap.check_encryption(:start_tls)
+  end
+
+  def test_tls_validation
+    assert_equal({ method: :start_tls, tls_options: OpenSSL::SSL::VERIFY_PEER },
+                 @ldap.check_encryption(:tls, true))
+    assert_equal({ method: :start_tls, tls_options: {} },
+                 @ldap.check_encryption(:tls, false))
+    assert_equal({ method: :start_tls, tls_options: {} },
+                 @ldap.check_encryption(:tls, nil))
+    assert_equal({ method: :start_tls, tls_options: {} },
+                 @ldap.check_encryption(:tls, 'true'))
+    assert_equal({ method: :start_tls, tls_options: {} },
+                 @ldap.check_encryption(:tls))
   end
 
   def test_search_delegator

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -25,14 +25,14 @@ module GitHubLdapTestCases
   end
 
   def test_simple_tls
-    expected = { method: :simple_tls, tls_options: {} }
+    expected = { method: :simple_tls, tls_options:  { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
     assert_equal expected, @ldap.check_encryption(:ssl)
     assert_equal expected, @ldap.check_encryption('SSL')
     assert_equal expected, @ldap.check_encryption(:simple_tls)
   end
 
   def test_start_tls
-    expected = { method: :start_tls, tls_options: {} }
+    expected = { method: :start_tls, tls_options: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
     assert_equal expected, @ldap.check_encryption(:tls)
     assert_equal expected, @ldap.check_encryption('TLS')
     assert_equal expected, @ldap.check_encryption(:start_tls)

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -41,13 +41,13 @@ module GitHubLdapTestCases
   def test_tls_validation
     assert_equal({ method: :start_tls, tls_options: { verify_mode: OpenSSL::SSL::VERIFY_PEER } },
                  @ldap.check_encryption(:tls, true))
-    assert_equal({ method: :start_tls, tls_options: {} },
+    assert_equal({ method: :start_tls, tls_options: { verify_mode: OpenSSL::SSL::VERIFY_NONE } },
                  @ldap.check_encryption(:tls, false))
-    assert_equal({ method: :start_tls, tls_options: {} },
+    assert_equal({ method: :start_tls, tls_options: { verify_mode: OpenSSL::SSL::VERIFY_NONE } },
                  @ldap.check_encryption(:tls, nil))
-    assert_equal({ method: :start_tls, tls_options: {} },
+    assert_equal({ method: :start_tls, tls_options: { verify_mode: OpenSSL::SSL::VERIFY_NONE } },
                  @ldap.check_encryption(:tls, 'true'))
-    assert_equal({ method: :start_tls, tls_options: {} },
+    assert_equal({ method: :start_tls, tls_options: { verify_mode: OpenSSL::SSL::VERIFY_NONE } },
                  @ldap.check_encryption(:tls))
   end
 

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -39,7 +39,7 @@ module GitHubLdapTestCases
   end
 
   def test_tls_validation
-    assert_equal({ method: :start_tls, tls_options: OpenSSL::SSL::VERIFY_PEER },
+    assert_equal({ method: :start_tls, tls_options: { verify_mode: OpenSSL::SSL::VERIFY_PEER } },
                  @ldap.check_encryption(:tls, true))
     assert_equal({ method: :start_tls, tls_options: {} },
                  @ldap.check_encryption(:tls, false))

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -45,6 +45,8 @@ module GitHubLdapTestCases
                  @ldap.check_encryption(:tls, verify_mode: OpenSSL::SSL::VERIFY_NONE))
     assert_equal({ method: :start_tls, tls_options: { cert_store: "some/path" } },
                  @ldap.check_encryption(:tls, cert_store: "some/path"))
+    assert_equal({ method: :start_tls, tls_options: {} },
+                 @ldap.check_encryption(:tls, nil))
   end
 
   def test_search_delegator


### PR DESCRIPTION
Enable by setting `validate_encryption: true` on initialization options

This is work needed to satisfy github/github#50387 by allowing the option to turn on validation.  The hash structure matches the return value from [check_encryption in ruby-net-ldap](https://github.com/ruby-ldap/ruby-net-ldap/blob/78e97ed69dc9ebbf06b04e7e70ceb046c23de75c/lib/net/ldap.rb#L1333).

/cc @github/platform-iam for review
/cc @github/enterprise-on-prem for 👀 