### PR TITLE
Loosen net-ldap requirement this allows for ldap 0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ addons:
     - ad1.ghe.dev
     - ad2.ghe.dev
 
+before_install:
+  - echo "deb http://ftp.br.debian.org/debian stable main" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update
+
 install:
   - if [ "$TESTENV" = "openldap" ]; then ./script/install-openldap; fi
   - bundle install

--- a/github-ldap.gemspec
+++ b/github-ldap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'net-ldap', '~> 0.16.0'
+  spec.add_dependency 'net-ldap', '> 0.16.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'ladle'

--- a/lib/github/ldap.rb
+++ b/lib/github/ldap.rb
@@ -228,7 +228,7 @@ module GitHub
         instrument "capabilities.github_ldap" do |payload|
           begin
             @connection.search_root_dse
-          rescue Net::LDAP::LdapError => error
+          rescue Net::LDAP::Error => error
             payload[:error] = error
             # stubbed result
             Net::LDAP::Entry.new

--- a/script/install-openldap
+++ b/script/install-openldap
@@ -13,10 +13,8 @@ TMPDIR=$(mktemp -d)
 cd $TMPDIR
 
 # Delete data and reconfigure.
-sudo cp -v /var/lib/ldap/DB_CONFIG ./DB_CONFIG
 sudo rm -rf /etc/ldap/slapd.d/*
 sudo rm -rf /var/lib/ldap/*
-sudo cp -v ./DB_CONFIG /var/lib/ldap/DB_CONFIG
 sudo slapadd -F /etc/ldap/slapd.d -b "cn=config" -l $BASE_PATH/slapd.conf.ldif
 # Load memberof and ref-int overlays and configure them.
 sudo slapadd -F /etc/ldap/slapd.d -b "cn=config" -l $BASE_PATH/memberof.ldif

--- a/test/domain_test.rb
+++ b/test/domain_test.rb
@@ -236,7 +236,8 @@ end
 
 class GitHubLdapActiveDirectoryGroupsTest < GitHub::Ldap::Test
   def run(*)
-    self.class.test_env == "activedirectory" ? super : self
+    return super if self.class.test_env == "activedirectory"
+    Minitest::Result.from(self)
   end
 
   def test_filter_groups

--- a/test/member_search/active_directory_test.rb
+++ b/test/member_search/active_directory_test.rb
@@ -3,7 +3,8 @@ require_relative '../test_helper'
 class GitHubLdapActiveDirectoryMemberSearchStubbedTest < GitHub::Ldap::Test
   # Only run when AD integration tests aren't run
   def run(*)
-    self.class.test_env != "activedirectory" ? super : self
+    return super if self.class.test_env != "activedirectory"
+    Minitest::Result.from(self)
   end
 
   def find_group(cn)
@@ -46,7 +47,8 @@ end
 class GitHubLdapActiveDirectoryMemberSearchIntegrationTest < GitHub::Ldap::Test
   # Only run this test suite if ActiveDirectory is configured
   def run(*)
-    self.class.test_env == "activedirectory" ? super : self
+    return super if self.class.test_env == "activedirectory"
+    Minitest::Result.from(self)
   end
 
   def find_group(cn)

--- a/test/membership_validators/active_directory_test.rb
+++ b/test/membership_validators/active_directory_test.rb
@@ -3,7 +3,8 @@ require_relative '../test_helper'
 class GitHubLdapActiveDirectoryMembershipValidatorsStubbedTest < GitHub::Ldap::Test
   # Only run when AD integration tests aren't run
   def run(*)
-    self.class.test_env != "activedirectory" ? super : self
+    return super if self.class.test_env != "activedirectory"
+    Minitest::Result.from(self)
   end
 
   def setup
@@ -72,7 +73,8 @@ end
 class GitHubLdapActiveDirectoryMembershipValidatorsIntegrationTest < GitHub::Ldap::Test
   # Only run this test suite if ActiveDirectory is configured
   def run(*)
-    self.class.test_env == "activedirectory" ? super : self
+    return super if self.class.test_env == "activedirectory"
+    Minitest::Result.from(self)
   end
 
   def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ require 'github/ldap/server'
 require 'minitest/mock'
 require 'minitest/autorun'
 
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 if ENV.fetch('TESTENV', "apacheds") == "apacheds"
   # Make sure we clean up running test server

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,8 +31,9 @@ class GitHub::Ldap::Test < Minitest::Test
 
   def self.run(reporter, options = {})
     start_server
-    super
+    result = super
     stop_server
+    result
   end
 
   def self.stop_server

--- a/test/user_search/active_directory_test.rb
+++ b/test/user_search/active_directory_test.rb
@@ -20,7 +20,7 @@ class GitHubLdapActiveDirectoryUserSearchTests < GitHub::Ldap::Test
     mock_global_catalog_connection = mock("GitHub::Ldap::UserSearch::GlobalCatalog")
     stub_entry = mock("Net::LDAP::Entry")
 
-    mock_global_catalog_connection.expects(:search).returns(stub_entry)
+    mock_global_catalog_connection.expects(:search).returns([stub_entry])
     ad_user_search.expects(:global_catalog_connection).returns(mock_global_catalog_connection)
 
     results = ad_user_search.perform("login", "CN=Joe", "uid", {})


### PR DESCRIPTION
This version of net-ldap is required to run ruby 3 without warnings